### PR TITLE
Fix ATX Bitcoiners Sphinx Chat Link

### DIFF
--- a/_posts/2022-05-19-socratic-seminar-28.md
+++ b/_posts/2022-05-19-socratic-seminar-28.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/Austin-Bitcoin-Developers/events/285214961/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 
 

--- a/_posts/2022-06-16-socratic-seminar-29.md
+++ b/_posts/2022-06-16-socratic-seminar-29.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215002/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Satoshi Labs Sponsored Bitcoin Commons Open Call](https://docs.google.com/forms/d/e/1FAIpQLSfwu1WAxjCwoAqUIpsXTS6XYsT5KsAbn80CsRoSoZF8lDdN6g/viewform)
 

--- a/_posts/2022-07-21-socratic-seminar-30.md
+++ b/_posts/2022-07-21-socratic-seminar-30.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215038/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Des Femmes Mentorship Program](https://desfemmesmagazine.com/blogs/news/mentorship-program)
 - [Base58 summer series](https://twitter.com/base58btc/status/1544140600622055426?s=21&t=XVfc7380naOTz6v7SOJxaw)

--- a/_posts/2022-08-18-socratic-seminar-31.md
+++ b/_posts/2022-08-18-socratic-seminar-31.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215133/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Nostr Workshop](https://www.meetup.com/pleb-lab/events/287761996/)
 - [IRL base58](https://twitter.com/base58btc/status/1559296871218176001)

--- a/_posts/2022-09-15-socratic-seminar-32.md
+++ b/_posts/2022-09-15-socratic-seminar-32.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215204/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [IRL base58](https://twitter.com/base58btc/status/1559296871218176001)
 - [Silicon Salon 2](https://www.siliconsalon.info/)

--- a/_posts/2022-10-20-socratic-seminar-33.md
+++ b/_posts/2022-10-20-socratic-seminar-33.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215279/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Legends of Lightning Tournament](https://makers.bolt.fun/tournaments/1/overview)
 - [BIP Bounty Launch](https://twitter.com/notasithlord/status/1580942321108910080)

--- a/_posts/2022-11-17-socratic-seminar-34.md
+++ b/_posts/2022-11-17-socratic-seminar-34.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215406/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Bitcoin++ Conference in Mexico City Dec 9-11](https://btcplusplus.dev/)
 - [Bitcoin Program at UT - Liaison Wanted](https://docs.google.com/document/d/1TY4OKHJrhr4KPYbOJiFwJEptls5JsfW-/edit?usp=sharing&ouid=101122673877611762018&rtpof=true&sd=true)

--- a/_posts/2022-12-09-ut-socratic-seminar.md
+++ b/_posts/2022-12-09-ut-socratic-seminar.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 
 

--- a/_posts/2022-12-15-socratic-seminar-35.md
+++ b/_posts/2022-12-15-socratic-seminar-35.md
@@ -10,7 +10,7 @@ meetup: https://www.meetup.com/austin-bitcoin-developers/events/285215416/
 - Respect people's privacy
 - Interaction and asking questions are encouraged
 - [Chatham House Rules](https://www.chathamhouse.org/about-us/chatham-house-rule)
-- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintaexasbitcoiners)
+- Join our Telegram group (https://t.me/BitcoinAustin) [QR](../assets/imgs/telegram-group.svg) or [Sphinx Chat](https://tribes.sphinx.chat/t/austintexasbitcoiners)
 - [Bitcoiner Jobs](https://bitcoinerjobs.co/)
 - [Silicon Salon 3 (January 2023)](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-November/021213.html)
 - [Build on L2](https://www.buildonl2.com/)


### PR DESCRIPTION
Fixes the broken link that makes it slightly harder to find the [Austin Texas Bitcoiners](https://tribes.sphinx.chat/t/austintexasbitcoiners) Sphinx tribe link. 